### PR TITLE
chore: TypeScriptチェックスキップスクリプトを削除

### DIFF
--- a/packages/frontend/src/pages/InventoryPage.test.tsx
+++ b/packages/frontend/src/pages/InventoryPage.test.tsx
@@ -113,7 +113,7 @@ describe('InventoryPage', () => {
       value: vi.fn().mockReturnValue(true),
     });
     const { デフォルトアイテムAPIサービス } = await import('../services/itemApi');
-    mockItemApiService = デフォルトアイテムAPIサービス as any;
+    mockItemApiService = デフォルトアイテムAPIサービス as unknown as typeof mockItemApiService;
     
     // デフォルトのAPIレスポンス
     mockItemApiService.インベントリ取得.mockResolvedValue({

--- a/packages/frontend/src/pages/ShopPage.test.tsx
+++ b/packages/frontend/src/pages/ShopPage.test.tsx
@@ -102,7 +102,7 @@ describe('ShopPage', () => {
       value: vi.fn().mockReturnValue(true),
     });
     const { デフォルトアイテムAPIサービス } = await import('../services/itemApi');
-    mockItemApiService = デフォルトアイテムAPIサービス as any;
+    mockItemApiService = デフォルトアイテムAPIサービス as unknown as typeof mockItemApiService;
     
     // デフォルトのAPIレスポンス
     mockItemApiService.全アイテムマスター取得.mockResolvedValue(モックアイテムマスタ);


### PR DESCRIPTION
## 概要
一時的に追加していた `build:skip-check` スクリプトを削除

## 変更内容
- ✅ `packages/frontend/package.json` から `build:skip-check` スクリプトを削除
- ✅ 通常の TypeScript チェック付きビルドに戻す

## 理由
D1統合とAPI修正が完了し、フロントエンドとバックエンドの連携が正常に動作することを確認したため、一時的に追加していたTypeScriptチェックスキップスクリプトを削除します。

## 影響
- 今後のビルドでは再びTypeScriptの型チェックが実行される
- CI/CDパイプラインでのビルド時にTypeScriptエラーが検出される

## 次のステップ
このPRマージ後、残存するTypeScriptエラーを段階的に修正していく必要があります。

🤖 Generated with [Claude Code](https://claude.ai/code)