### PR TITLE
fix: デプロイメントでのマルチバイト文字エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,15 @@ jobs:
       - name: "🔍 デプロイ条件チェック"
         id: check
         run: |
-          # コミットメッセージ取得
+          # コミットメッセージ取得（マルチバイト文字対応）
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
-          echo "commit-message=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+          
+          # 初学者向け：GITHUB_OUTPUTでマルチライン・マルチバイト文字を安全に設定
+          {
+            echo "commit-message<<EOF"
+            echo "$COMMIT_MESSAGE"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
           
           # デプロイをスキップするキーワードをチェック
           if echo "$COMMIT_MESSAGE" | grep -E "(skip deploy|no deploy)" > /dev/null; then


### PR DESCRIPTION
## 🔧 修正内容

GitHub Actions の GITHUB_OUTPUT でマルチバイト文字（日本語）を含むコミットメッセージを処理する際のエラーを修正しました。

## 🐛 修正された問題

- **Issue**: #38
- **エラー**: `Invalid format 'fix: 全ESLintエラー修正とCI全テスト再有効化'`
- **原因**: GITHUB_OUTPUT でのマルチバイト文字処理エラー

## 🚀 変更点

### `.github/workflows/deploy.yml`

**修正前:**
```yaml
COMMIT_MESSAGE=$(git log -1 --pretty=%B)
echo "commit-message=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
```

**修正後:**
```yaml
COMMIT_MESSAGE=$(git log -1 --pretty=%B)

# 初学者向け：GITHUB_OUTPUTでマルチライン・マルチバイト文字を安全に設定
{
  echo "commit-message<<EOF"
  echo "$COMMIT_MESSAGE"
  echo "EOF"
} >> $GITHUB_OUTPUT
```

## 🎯 修正のポイント

1. **マルチライン形式の採用**: `<<EOF` 区切りを使用してマルチバイト文字を安全に処理
2. **GitHub Actions 推奨パターン**: 公式ドキュメントに従った出力設定方法
3. **エンコーディング対応**: 日本語文字を含むコミットメッセージでもエラーが発生しない

## ✅ テスト計画

- [ ] CI パイプラインが正常に動作することを確認
- [ ] デプロイ条件チェックが成功することを確認
- [ ] マルチバイト文字を含むコミットメッセージでテスト
- [ ] main ブランチマージ後のデプロイメント動作確認

## 📚 参考資料

- [GitHub Actions: Setting outputs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)
- [マルチライン出力の設定方法](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>