### PR TITLE
fix: Cloudflare PagesプロジェクトIDを既存プロジェクトに修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: pokemon-like-game
+          projectName: pokemon-game-frontend
           directory: packages/frontend/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## 🔧 修正内容

Cloudflare Pagesデプロイメントで使用するプロジェクト名を既存のプロジェクトに合わせて修正しました。

## 🚀 変更点

### `.github/workflows/deploy.yml`

**修正前:**
```yaml
projectName: pokemon-like-game
```

**修正後:**
```yaml
projectName: pokemon-game-frontend
```

## 🎯 修正の理由

1. **既存プロジェクトの存在**: Cloudflareアカウントに `pokemon-game-frontend` が既に存在
2. **デプロイメントエラー**: プロジェクト名の不一致によりデプロイが失敗
3. **GitHub Secrets設定完了**: CLOUDFLARE_API_TOKEN と CLOUDFLARE_ACCOUNT_ID が設定済み

## ✅ テスト計画

- [ ] CI パイプラインが正常に動作することを確認
- [ ] Cloudflare Pagesへのデプロイメントが成功することを確認
- [ ] https://pokemon-game-frontend-120.pages.dev でアプリケーションが動作することを確認

## 📊 Cloudflareリソース状況

- **アカウントID**: b206ff3a1f57cd57469b20adaf8be123
- **Pagesプロジェクト**: pokemon-game-frontend（既存）
- **URL**: https://pokemon-game-frontend-120.pages.dev

これでGitHub Secretsと組み合わせてデプロイメントが正常に動作するはずです。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>